### PR TITLE
feature: 여행로그 데이터셋 마이그레이션, 중심지와의 거리 반환

### DIFF
--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
@@ -1,5 +1,7 @@
 package com.yeohangttukttak.api.domain.file.entity;
 
+import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.global.interfaces.Attachable;
 import com.yeohangttukttak.api.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -7,6 +9,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -15,6 +21,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class File extends BaseEntity {
 
     @Id @GeneratedValue
+    @Column(name = "file_id")
     private Long id;
 
     private String name;
@@ -22,6 +29,17 @@ public class File extends BaseEntity {
     private String url;
 
     private String mimeType;
+
+//    @OneToOne(fetch = LAZY)
+//    private Travel travel;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "visit_id")
+    private Visit visit;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "travel_id")
+    private Travel travel;
 
     @Builder
     public File(Long id, String name, String url, String mimeType) {

--- a/src/main/java/com/yeohangttukttak/api/domain/member/entity/AgeGroup.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/member/entity/AgeGroup.java
@@ -9,7 +9,8 @@ public enum AgeGroup implements ValueBasedEnum {
     S20("20s"), // 20 ~ 30대
     S30("30s"), // 30 ~ 40대
     S40("40s"), // 40 ~ 50대
-    P50("50p");  // 50대 이상
+    S50("50s"), // 50 ~ 60대
+    P60("60s"); // 60대 ~
 
     private final String value;
 

--- a/src/main/java/com/yeohangttukttak/api/domain/member/entity/Gender.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/member/entity/Gender.java
@@ -1,0 +1,20 @@
+package com.yeohangttukttak.api.domain.member.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.yeohangttukttak.api.global.interfaces.ValueBasedEnum;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Gender implements ValueBasedEnum {
+
+    MALE("male"),
+    FEMALE("female");
+
+    private String value;
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/src/main/java/com/yeohangttukttak/api/domain/member/entity/Member.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/member/entity/Member.java
@@ -21,10 +21,14 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AgeGroup ageGroup;
 
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
     @Builder
-    public Member(Long id, String nickname, AgeGroup ageGroup) {
+    public Member(Long id, String nickname, AgeGroup ageGroup, Gender gender) {
         this.id = id;
         this.nickname = nickname;
         this.ageGroup = ageGroup;
+        this.gender = gender;
     }
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/member/entity/Member.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/member/entity/Member.java
@@ -14,6 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 public class Member extends BaseEntity {
 
     @Id @GeneratedValue
+    @Column(name = "member_id")
     private Long id;
 
     private String nickname;

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/LocationDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/LocationDTO.java
@@ -5,23 +5,32 @@ import com.yeohangttukttak.api.global.config.validator.ValidLatitude;
 import com.yeohangttukttak.api.global.config.validator.ValidLongitude;
 import lombok.Data;
 
+import java.text.DecimalFormat;
+
 @Data
 public class LocationDTO {
 
     @ValidLatitude
-    private double latitude;
+    private Double latitude;
 
     @ValidLongitude
-    private double longitude;
+    private Double longitude;
+
+    private Double distance;
 
     public LocationDTO (Location location) {
-        this.latitude = location.getLatitude();
+        this.latitude = location.getLatitude() ;
         this.longitude = location.getLongitude();
     }
 
     public LocationDTO (Double latitude, Double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
+    }
+
+    public void setDistance(Double distance) {
+        DecimalFormat df = new DecimalFormat("#.##");
+        this.distance = Double.parseDouble(df.format(distance * 100));
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -29,7 +29,7 @@ public class PlaceDTO {
         this.id = place.getId();
         this.name = place.getName();
         this.type = place.getType();
-        this.location = new LocationDTO(new Location(place.getPoint()));
+        this.location = new LocationDTO(place.getLocation());
         this.images = place.getFiles().stream().map(ImageDTO::new).toList();
     }
 

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -37,25 +37,14 @@ public class PlaceDTO {
         this.name = place.getName();
         this.type = place.getType();
         this.location = new LocationDTO(place.getLocation());
-        this.images = place.getFiles().stream()
-                .sorted(comparing(File::getId))
-                .limit(5)
-                .map(ImageDTO::new)
-                .toList();
     }
 
-    public PlaceDTO(Entry<Place, List<VisitSearchResult>> entry) {
-        this(entry.getKey());
-        List<VisitSearchResult> results = entry.getValue();
+    public PlaceDTO(Place place, List<Reference> travels, List<ImageDTO> imageDTOS, Double distance) {
+        this(place);
 
-        location.setDistance(results.get(0).getDistance());
-
-        travels = results.stream()
-                .map(VisitSearchResult::getTravel)
-                .map(result -> new Reference(result.getId(), "travel"))
-                .distinct()
-                .sorted(comparing(Reference::getId))
-                .toList();
+        this.getLocation().setDistance(distance);
+        this.travels = travels;
+        this.images = imageDTOS;
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -1,5 +1,6 @@
 package com.yeohangttukttak.api.domain.place.dto;
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
+import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.place.entity.Location;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.place.entity.PlaceType;
@@ -36,7 +37,11 @@ public class PlaceDTO {
         this.name = place.getName();
         this.type = place.getType();
         this.location = new LocationDTO(place.getLocation());
-        this.images = place.getFiles().stream().map(ImageDTO::new).toList();
+        this.images = place.getFiles().stream()
+                .sorted(comparing(File::getId))
+                .limit(5)
+                .map(ImageDTO::new)
+                .toList();
     }
 
     public PlaceDTO(Entry<Place, List<VisitSearchResult>> entry) {

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -4,10 +4,16 @@ import com.yeohangttukttak.api.domain.place.entity.Location;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.place.entity.PlaceType;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import com.yeohangttukttak.api.global.common.Reference;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.*;
+import java.util.Map.Entry;
+
+import static java.util.Comparator.comparing;
 
 
 @Data
@@ -33,23 +39,18 @@ public class PlaceDTO {
         this.images = place.getFiles().stream().map(ImageDTO::new).toList();
     }
 
-
-    public PlaceDTO(Map.Entry<Place, List<Travel>> entry) {
+    public PlaceDTO(Entry<Place, List<VisitSearchResult>> entry) {
         this(entry.getKey());
+        List<VisitSearchResult> results = entry.getValue();
 
-        this.travels = entry.getValue().stream()
-                .map(travel -> new Reference(travel.getId(), "travel"))
-                .distinct().toList();
-    }
+        location.setDistance(results.get(0).getDistance());
 
-    @Data
-    @AllArgsConstructor
-    public static class Reference {
-
-        private Long id;
-
-        private String type;
-
+        travels = results.stream()
+                .map(VisitSearchResult::getTravel)
+                .map(result -> new Reference(result.getId(), "travel"))
+                .distinct()
+                .sorted(comparing(Reference::getId))
+                .toList();
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/place/entity/Location.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/entity/Location.java
@@ -1,19 +1,25 @@
 package com.yeohangttukttak.api.domain.place.entity;
 
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.geolatte.geom.Point;
+import org.geolatte.geom.jts.JTS;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 
 @Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location {
 
-    private final Double latitude;
+    private Double latitude;
 
-    private final Double longitude;
+    private Double longitude;
 
-    private final Point point;
+    private Point point;
 
     // 클래스 레벨의 정적 변수로 선언해 한 번만 초기화 한다.
     private static final GeometryFactory factory = new GeometryFactory(
@@ -22,13 +28,13 @@ public class Location {
     public Location (Double latitude, Double longitude) {
         this.latitude = latitude;
         this.longitude = longitude;
-        this.point = factory.createPoint(new Coordinate(longitude, latitude));
+        this.point = JTS.from(factory.createPoint(new Coordinate(longitude, latitude)));
     }
 
     public Location (Point point) {
         this.point = point;
-        this.latitude = point.getCoordinate().y;
-        this.longitude = point.getCoordinate().x;
+        this.longitude = point.getPosition().getCoordinate(0);
+        this.latitude = point.getPosition().getCoordinate(1);
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/place/entity/Place.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/entity/Place.java
@@ -8,8 +8,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
-import org.locationtech.jts.geom.Point;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +29,8 @@ public class Place extends BaseEntity implements Attachable {
     @Enumerated(EnumType.STRING)
     private PlaceType type;
 
-    private Point point;
+    @Embedded
+    private Location location;
 
     @OneToMany(mappedBy = "place")
     private List<Visit> visits = new ArrayList<>();
@@ -45,7 +44,7 @@ public class Place extends BaseEntity implements Attachable {
         this.id = id;
         this.name = name;
         this.type = type;
-        this.point = location.getPoint();
+        this.location = location;
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/place/entity/Place.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/entity/Place.java
@@ -1,8 +1,6 @@
 package com.yeohangttukttak.api.domain.place.entity;
 
-import com.yeohangttukttak.api.global.interfaces.Attachable;
 import com.yeohangttukttak.api.domain.BaseEntity;
-import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -18,7 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Place extends BaseEntity implements Attachable {
+public class Place extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "place_id")
@@ -35,9 +33,7 @@ public class Place extends BaseEntity implements Attachable {
     @OneToMany(mappedBy = "place")
     private List<Visit> visits = new ArrayList<>();
 
-    @OneToMany
-    @JoinColumn(name = "place_id")
-    private List<File> files = new ArrayList<>();
+    private String googlePlaceId;
 
     @Builder
     public Place(Long id, String name, PlaceType type, Location location) {

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
@@ -42,12 +42,8 @@ public class TravelDTO {
         this.startedOn = travel.getPeriod().getStartedOn();
         this.endedOn = travel.getPeriod().getEndedOn();
 
-        this.thumbnail = new ImageDTO(travel.getThumbnail());
+        this.thumbnail = travel.getThumbnail() != null ? new ImageDTO(travel.getThumbnail()) : null;
         this.member = new MemberDTO(travel.getMember());
-    }
-
-    public TravelDTO(VisitSearchResult result) {
-        this(result.getTravel());
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
@@ -1,6 +1,7 @@
 package com.yeohangttukttak.api.domain.travel.dto;
 
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
+import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.member.dto.MemberDTO;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.AccompanyType;
@@ -33,7 +34,7 @@ public class TravelDTO {
 
     private MemberDTO member;
 
-    public TravelDTO(Travel travel) {
+    public TravelDTO(Travel travel, ImageDTO thumbnail) {
         this.id = travel.getId();
         this.name = travel.getName();
         this.motivation = travel.getMotivation();
@@ -42,7 +43,7 @@ public class TravelDTO {
         this.startedOn = travel.getPeriod().getStartedOn();
         this.endedOn = travel.getPeriod().getEndedOn();
 
-        this.thumbnail = travel.getThumbnail() != null ? new ImageDTO(travel.getThumbnail()) : null;
+        this.thumbnail = thumbnail;
         this.member = new MemberDTO(travel.getMember());
     }
 

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
@@ -7,6 +7,7 @@ import com.yeohangttukttak.api.domain.travel.entity.AccompanyType;
 import com.yeohangttukttak.api.domain.travel.entity.Motivation;
 import com.yeohangttukttak.api.domain.travel.entity.TransportType;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -43,6 +44,10 @@ public class TravelDTO {
 
         this.thumbnail = new ImageDTO(travel.getThumbnail());
         this.member = new MemberDTO(travel.getMember());
+    }
+
+    public TravelDTO(VisitSearchResult result) {
+        this(result.getTravel());
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/AccompanyType.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/AccompanyType.java
@@ -11,6 +11,7 @@ public enum AccompanyType implements ValueBasedEnum {
     FRIENDS("friends"),    // 지인과
     PARENTS("parents"),    // 부모님과
     CHILDREN("children"),   // 자녀와
+    FAMILY("family"),
     OTHERS("others");      // 기타
 
     private final String value;

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Motivation.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Motivation.java
@@ -6,12 +6,15 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum Motivation implements ValueBasedEnum {
-    EXIST("existing"),          // 재미
-    EDUCATION("education"),     // 교육
+    REFRESH("refresh"),          // 재미
+    RELAX("relax"),
+    EDU("education"),     // 교육
     SOCIAL("social"),           // 친목
     REFLECT("reflect"),         // 성찰
-    EXPERIENCE("experience"),   // 경험
-    RELAX("relax");             // 힐링
+    SNS("sns"),
+    ENERGY("energy"),
+    EXPR("experience"),   // 경험
+    OTHERS("others");             // 힐링
 
     private final String value;
 

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/TransportType.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/TransportType.java
@@ -7,7 +7,10 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum TransportType implements ValueBasedEnum {
     CAR ("car"),
-    PUBLIC ("public");
+    PUBLIC ("public"),
+    CYCLE("cycle"),
+    WORK("work"),
+    OTHERS("others");
 
     private final String value;
 

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
@@ -45,7 +45,7 @@ public class Travel extends BaseEntity {
     @OneToMany(mappedBy = "travel")
     private List<Visit> visits = new ArrayList<>();
 
-    @OneToOne
+    @OneToOne(fetch = LAZY)
     @JoinColumn(name = "thumbnail_id")
     private File thumbnail;
 

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
@@ -4,6 +4,7 @@ import com.yeohangttukttak.api.domain.BaseEntity;
 import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.member.entity.Member;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import com.yeohangttukttak.api.global.interfaces.Attachable;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -19,9 +20,10 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity @Getter
 @NoArgsConstructor(access = PROTECTED)
 @EqualsAndHashCode
-public class Travel extends BaseEntity {
+public class Travel extends BaseEntity implements Attachable {
 
     @Id @GeneratedValue
+    @Column(name = "travel_id")
     private Long id;
 
     private String name;
@@ -45,9 +47,8 @@ public class Travel extends BaseEntity {
     @OneToMany(mappedBy = "travel")
     private List<Visit> visits = new ArrayList<>();
 
-    @OneToOne(fetch = LAZY)
-    @JoinColumn(name = "thumbnail_id")
-    private File thumbnail;
+    @OneToMany(mappedBy = "travel")
+    private List<File> files = new ArrayList<>();
 
     @Builder
     public Travel(Long id, String name,

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
@@ -1,28 +1,30 @@
 package com.yeohangttukttak.api.domain.visit.dao;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.BooleanTemplate;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.spatial.GeometryExpression;
+import com.querydsl.spatial.GeometryExpressions;
 import com.yeohangttukttak.api.domain.member.entity.AgeGroup;
 import com.yeohangttukttak.api.domain.place.entity.Location;
-import com.yeohangttukttak.api.domain.travel.entity.AccompanyType;
-import com.yeohangttukttak.api.domain.travel.entity.Motivation;
-import com.yeohangttukttak.api.domain.travel.entity.Season;
-import com.yeohangttukttak.api.domain.travel.entity.TransportType;
+import com.yeohangttukttak.api.domain.travel.entity.*;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearch;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
+import org.geolatte.geom.Geometry;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Set;
 
+import static com.querydsl.spatial.GeometryExpressions.asGeometry;
 import static com.yeohangttukttak.api.domain.place.entity.QPlace.place;
 import static com.yeohangttukttak.api.domain.travel.entity.QTravel.travel;
 import static com.yeohangttukttak.api.domain.visit.entity.QVisit.visit;
-
 
 @Repository
 @Slf4j
@@ -34,9 +36,15 @@ public class VisitRepository {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 
-    public List<Visit> search(VisitSearch search) {
-        List<Visit> visits = queryFactory
-                .selectFrom(visit)
+    public List<VisitSearchResult> search(VisitSearch search) {
+
+        NumberExpression<Double> distanceExpr = asGeometry(place.location.point)
+                .distance(asGeometry(search.getLocation().getPoint())
+        );
+
+        List<Tuple> result = queryFactory
+                .select(visit, travel, distanceExpr)
+                .from(visit)
                 .join(visit.travel, travel).fetchJoin()
                 .join(visit.place, place).fetchJoin()
                 .where(dwithin(search.getLocation(), search.getRadius()),
@@ -46,23 +54,15 @@ public class VisitRepository {
                         transportTypesIn(search.getTransportTypes())
                 ).fetch();
 
-        return visits.stream()
-                .filter(visit -> seasonsIn(search, visit))
+        return result.stream().map(VisitSearchResult::new)
+                .filter(record -> seasonsIn(search, record.getTravel()))
                 .toList();
-    }
-
-    private boolean seasonsIn(VisitSearch search, Visit visit) {
-        if (search.getSeasons() == null) return true;
-
-        Set<Season> intersection = visit.getTravel().getPeriod().getSeasons();
-        intersection.retainAll(search.getSeasons());
-        return !intersection.isEmpty();
     }
 
     private BooleanTemplate dwithin(Location location, int radius) {
         return Expressions.booleanTemplate(
                 "st_dwithin({0}, {1}, {2}, false) is true",
-                place.point,
+                place.location.point,
                 location.getPoint(),
                 radius
         );
@@ -84,4 +84,11 @@ public class VisitRepository {
         return transportTypes != null ? travel.transportType.in(transportTypes) : null;
     }
 
+    private boolean seasonsIn(VisitSearch search, Travel travel) {
+        if (search.getSeasons() == null) return true;
+
+        Set<Season> intersection = travel.getPeriod().getSeasons();
+        intersection.retainAll(search.getSeasons());
+        return !intersection.isEmpty();
+    }
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
@@ -1,6 +1,7 @@
 package com.yeohangttukttak.api.domain.visit.dao;
 
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.BooleanTemplate;
 import com.querydsl.core.types.dsl.Expressions;
@@ -42,8 +43,9 @@ public class VisitRepository {
                 .distance(asGeometry(search.getLocation().getPoint())
         );
 
-        List<Tuple> result = queryFactory
-                .select(visit, travel, distanceExpr)
+        List<VisitSearchResult> result = queryFactory
+                .select(Projections.constructor(VisitSearchResult.class,
+                        visit, travel, place, distanceExpr))
                 .from(visit)
                 .join(visit.travel, travel).fetchJoin()
                 .join(visit.place, place).fetchJoin()
@@ -54,7 +56,7 @@ public class VisitRepository {
                         transportTypesIn(search.getTransportTypes())
                 ).fetch();
 
-        return result.stream().map(VisitSearchResult::new)
+        return result.stream()
                 .filter(record -> seasonsIn(search, record.getTravel()))
                 .toList();
     }

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitSearchResult.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitSearchResult.java
@@ -1,6 +1,6 @@
 package com.yeohangttukttak.api.domain.visit.dao;
 
-import com.querydsl.core.Tuple;
+import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import lombok.AllArgsConstructor;
@@ -14,12 +14,8 @@ public class VisitSearchResult {
 
     private Travel travel;
 
-    private Double distance;
+    private Place place;
 
-    public VisitSearchResult(Tuple tuple) {
-        visit = tuple.get(0, Visit.class);
-        travel = tuple.get(1, Travel.class);
-        distance = tuple.get(2, Double.class);
-    }
+    private Double distance;
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitSearchResult.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitSearchResult.java
@@ -1,0 +1,25 @@
+package com.yeohangttukttak.api.domain.visit.dao;
+
+import com.querydsl.core.Tuple;
+import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class VisitSearchResult {
+
+    private Visit visit;
+
+    private Travel travel;
+
+    private Double distance;
+
+    public VisitSearchResult(Tuple tuple) {
+        visit = tuple.get(0, Visit.class);
+        travel = tuple.get(1, Travel.class);
+        distance = tuple.get(2, Double.class);
+    }
+
+}

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dto/VisitSearch.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dto/VisitSearch.java
@@ -8,10 +8,12 @@ import com.yeohangttukttak.api.domain.travel.entity.Season;
 import com.yeohangttukttak.api.domain.travel.entity.TransportType;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Set;
 
 @Data
+@NoArgsConstructor
 public class VisitSearch {
 
     private Location location;

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
@@ -1,12 +1,17 @@
 package com.yeohangttukttak.api.domain.visit.entity;
 
 import com.yeohangttukttak.api.domain.BaseEntity;
+import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.global.interfaces.Attachable;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.FetchType.LAZY;
@@ -15,9 +20,10 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Visit extends BaseEntity {
+public class Visit extends BaseEntity implements Attachable {
 
     @Id @GeneratedValue
+    @Column(name = "visit_id")
     private Long id;
 
     private int dayOfTravel;
@@ -31,6 +37,9 @@ public class Visit extends BaseEntity {
     @ManyToOne(fetch = LAZY, cascade = ALL)
     @JoinColumn(name = "place_id")
     private Place place;
+
+    @OneToMany(mappedBy = "visit")
+    private List<File> files = new ArrayList<>();
 
     @Builder
     public Visit(Long id, int dayOfTravel, int orderOfVisit, Place place, Travel travel) {

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
@@ -33,7 +33,8 @@ public class Visit extends BaseEntity {
     private Place place;
 
     @Builder
-    public Visit(int dayOfTravel, int orderOfVisit, Place place, Travel travel) {
+    public Visit(Long id, int dayOfTravel, int orderOfVisit, Place place, Travel travel) {
+        this.id = id;
         this.dayOfTravel = dayOfTravel;
         this.orderOfVisit = orderOfVisit;
         this.place = place;

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
@@ -1,11 +1,16 @@
 package com.yeohangttukttak.api.domain.visit.service;
 
+import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
+import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
 import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
+import com.yeohangttukttak.api.domain.travel.entity.Travel;
 import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearch;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearchDTO;
 import com.yeohangttukttak.api.domain.visit.dao.VisitRepository;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import com.yeohangttukttak.api.global.common.Reference;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,14 +38,18 @@ public class VisitSearchService {
                             mapping(identity(), toList()
                         )))
                 .entrySet().stream()
-                .map(PlaceDTO::new)
+                .map(entry -> new PlaceDTO(entry.getKey(),
+                        getTravelRef(entry.getValue()),
+                        getPreviewImages(entry.getValue()),
+                        getDistance(entry.getValue()))
+                )
                 .sorted(comparing(PlaceDTO::getId))
                 .toList();
 
         // travelDTO 조립
         List<TravelDTO> travelDTOS = results.stream()
                 .map(VisitSearchResult::getTravel)
-                .map(TravelDTO::new)
+                .map(travel -> new TravelDTO(travel, getThumbnail(travel)))
                 .distinct()
                 .sorted(comparing(TravelDTO::getId))
                 .toList();
@@ -48,7 +57,34 @@ public class VisitSearchService {
         return new VisitSearchDTO(travelDTOS, placeDTOS);
     }
 
+    private Double getDistance(List<VisitSearchResult> results) {
+        return results.get(0).getDistance();
+    }
 
+    private List<ImageDTO> getPreviewImages(List<VisitSearchResult> results) {
+        return results.stream()
+                .map(VisitSearchResult::getVisit)
+                .map(Visit::getFiles)
+                .flatMap(Collection::stream)
+                .sorted(comparing(File::getId))
+                .limit(5)
+                .map(ImageDTO::new)
+                .toList();
+    }
+
+    private List<Reference> getTravelRef(List<VisitSearchResult> results) {
+        return results.stream()
+                .map(VisitSearchResult::getTravel)
+                .map(result -> new Reference(result.getId(), "travel"))
+                .distinct()
+                .sorted(comparing(Reference::getId))
+                .toList();
+    }
+
+    private ImageDTO getThumbnail(Travel travel) {
+        File thumbnail = travel.getFiles().stream().findFirst().orElse(null);
+        return thumbnail == null ? null : new ImageDTO(thumbnail);
+    }
 
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
@@ -1,9 +1,10 @@
 package com.yeohangttukttak.api.domain.visit.service;
 
+import com.querydsl.core.Tuple;
 import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
-import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
-import com.yeohangttukttak.api.domain.travel.entity.Travel;
+import com.yeohangttukttak.api.domain.travel.entity.Season;
+import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearch;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearchDTO;
@@ -13,9 +14,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static java.util.Comparator.comparing;
+import static java.util.Comparator.comparingDouble;
 import static java.util.stream.Collectors.*;
 
 @Service
@@ -25,8 +26,11 @@ public class VisitSearchService {
 
     private final VisitRepository visitRepository;
 
-    public VisitSearchDTO search(VisitSearch visitSearch) {
-        List<Visit> visits = visitRepository.search(visitSearch);
+    public VisitSearchDTO search(VisitSearch search) {
+        List<VisitSearchResult> result = visitRepository.search(search);
+
+        List<Visit> visits = result.stream().map(VisitSearchResult::getVisit).toList();
+        List<Double> distances = result.stream().map(VisitSearchResult::getDistance).toList();
 
         // place 탐색
         List<PlaceDTO> placeDTOS = visits.stream()
@@ -37,14 +41,27 @@ public class VisitSearchService {
                 .map(PlaceDTO::new)
                 .toList();
 
+        AtomicInteger index = new AtomicInteger();
+
+        placeDTOS = placeDTOS.stream()
+                .peek((placeDTO) ->
+                        placeDTO.getLocation()
+                        .setDistance(distances.get(index.getAndIncrement())))
+                .sorted(comparingDouble(PlaceDTO::getId))
+                .toList();
+
         // travelDTO 조립
         List<TravelDTO> travelDTOS = visits.stream()
                 .map(Visit::getTravel)
-                .map(TravelDTO::new)
                 .distinct()
+                .map(TravelDTO::new)
+                .sorted(comparingDouble(TravelDTO::getId))
                 .toList();
 
         return new VisitSearchDTO(travelDTOS, placeDTOS);
     }
+
+
+
 
 }

--- a/src/main/java/com/yeohangttukttak/api/global/common/Reference.java
+++ b/src/main/java/com/yeohangttukttak/api/global/common/Reference.java
@@ -1,0 +1,14 @@
+package com.yeohangttukttak.api.global.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Reference {
+
+    private Long id;
+
+    private String type;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
       hibernate:
         format_sql: true
         highlight_sql: true
-        default_batch_fetch_size: 100
+        default_batch_fetch_size: 1000
 
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
@@ -18,6 +18,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql: trace
 
 management:
   endpoints:

--- a/src/test/java/com/yeohangttukttak/api/repository/VisitRepositoryTest.java
+++ b/src/test/java/com/yeohangttukttak/api/repository/VisitRepositoryTest.java
@@ -5,6 +5,7 @@ import com.yeohangttukttak.api.domain.member.entity.Member;
 import com.yeohangttukttak.api.domain.place.entity.Location;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.*;
+import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
 import com.yeohangttukttak.api.domain.visit.dto.VisitSearch;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.domain.visit.dao.VisitRepository;
@@ -104,14 +105,16 @@ class VisitRepositoryTest {
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(search);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("그랜드 플라자가 있어야 한다.")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("구글 본사는 없어야 한다.")
                 .doesNotContain(visitB);
     }
@@ -119,21 +122,23 @@ class VisitRepositoryTest {
     @Test
     public void 연령_검색() throws Exception {
         // given
-        VisitSearch searchAll = VisitSearch.builder()
+        VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
                 .ageGroups(Set.of(AgeGroup.S20, AgeGroup.P50))
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(searchAll);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("20대의 여행은 반환되어야 한다.")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("30대의 여행은 반한되지 말아야 한다.")
                 .doesNotContain(visitB);
     }
@@ -142,21 +147,23 @@ class VisitRepositoryTest {
     @Test
     public void 계절_검색() throws Exception {
         // given
-        VisitSearch searchAll = VisitSearch.builder()
+        VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
                 .seasons(Set.of(Season.SPRING, Season.WINTER))
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(searchAll);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("봄 여행은 반환되어야 한다.")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("여름 여행은 반환되지 말아야 한다.")
                 .doesNotContain(visitB);
     }
@@ -164,21 +171,23 @@ class VisitRepositoryTest {
     @Test
     public void 동반_유형_검색() throws Exception {
         // given
-        VisitSearch searchAll = VisitSearch.builder()
+        VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
                 .accompanyTypes(Set.of(AccompanyType.PARENTS, AccompanyType.SOLO))
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(searchAll);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("부모 동반 여행은 반환되어야 한다..")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("자녀 동반 여행은 반환되지 말아야 한다.")
                 .doesNotContain(visitB);
     }
@@ -186,21 +195,23 @@ class VisitRepositoryTest {
     @Test
     public void 여행_동기_검색() throws Exception {
         // given
-        VisitSearch searchAll = VisitSearch.builder()
+        VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
                 .motivations(Set.of(Motivation.RELAX, Motivation.EXPERIENCE))
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(searchAll);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("힐링 여행은 반환되어야 한다..")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("교육 여행은 반환되지 말아야 한다.")
                 .doesNotContain(visitB);
     }
@@ -208,21 +219,23 @@ class VisitRepositoryTest {
     @Test
     public void 이동_수단_검색() throws Exception {
         // given
-        VisitSearch searchAll = VisitSearch.builder()
+        VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
                 .transportTypes(Set.of(TransportType.CAR))
                 .build();
 
         // when
-        List<Visit> foundVisits = visitRepository.search(searchAll);
+        List<VisitSearchResult> results = visitRepository.search(search);
 
         // then
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("자차 여행은 반환되어야 한다..")
                 .contains(visitA);
 
-        assertThat(foundVisits)
+        assertThat(results)
+                .extracting(VisitSearchResult::getVisit)
                 .as("대중교통 여행은 반환되지 말아야 한다.")
                 .doesNotContain(visitB);
     }

--- a/src/test/java/com/yeohangttukttak/api/repository/VisitRepositoryTest.java
+++ b/src/test/java/com/yeohangttukttak/api/repository/VisitRepositoryTest.java
@@ -72,7 +72,7 @@ class VisitRepositoryTest {
         travelB = Travel.builder()
                 .member(memberB)
                 .accompanyType(AccompanyType.CHILDREN)
-                .motivation(Motivation.EDUCATION)
+                .motivation(Motivation.EDU)
                 .transportType(TransportType.PUBLIC)
                 .period(new TravelPeriod(
                         LocalDate.parse("2022-08-15"),
@@ -125,7 +125,7 @@ class VisitRepositoryTest {
         VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
-                .ageGroups(Set.of(AgeGroup.S20, AgeGroup.P50))
+                .ageGroups(Set.of(AgeGroup.S20, AgeGroup.S50))
                 .build();
 
         // when
@@ -198,7 +198,7 @@ class VisitRepositoryTest {
         VisitSearch search = VisitSearch.builder()
                 .location(new Location(36.6600, 127.4900))
                 .radius(20000)
-                .motivations(Set.of(Motivation.RELAX, Motivation.EXPERIENCE))
+                .motivations(Set.of(Motivation.RELAX, Motivation.EXPR))
                 .build();
 
         // when

--- a/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
+++ b/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
@@ -1,0 +1,209 @@
+package com.yeohangttukttak.api.service.visit;
+
+import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
+import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.member.entity.AgeGroup;
+import com.yeohangttukttak.api.domain.member.entity.Member;
+import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
+import com.yeohangttukttak.api.domain.place.entity.Location;
+import com.yeohangttukttak.api.domain.place.entity.Place;
+import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
+import com.yeohangttukttak.api.domain.travel.entity.*;
+import com.yeohangttukttak.api.domain.visit.dao.VisitRepository;
+import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
+import com.yeohangttukttak.api.domain.visit.dto.VisitSearch;
+import com.yeohangttukttak.api.domain.visit.dto.VisitSearchDTO;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import com.yeohangttukttak.api.domain.visit.service.VisitSearchService;
+import com.yeohangttukttak.api.global.common.Reference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class VisitSearchServiceTest {
+
+    @InjectMocks
+    private VisitSearchService visitSearchService;
+
+    @Mock
+    private VisitRepository visitRepository;
+
+    Member memberA, memberB;
+    Travel travelA, travelB;
+    Place placeA, placeB;
+    Visit visitA, visitB, visitA2, visitB2;
+    List<File> files;
+
+    @BeforeEach
+    public void init() {
+
+        memberA = Member.builder()
+                .id(1L)
+                .ageGroup(AgeGroup.S20)
+                .build();
+
+        memberB = Member.builder()
+                .id(2L)
+                .ageGroup(AgeGroup.S30)
+                .build();
+
+        travelA = Travel.builder()
+                .id(1L)
+                .member(memberA)
+                .accompanyType(AccompanyType.PARENTS)
+                .motivation(Motivation.RELAX)
+                .transportType(TransportType.CAR)
+                .period(new TravelPeriod(
+                        LocalDate.parse("2022-03-19"),
+                        LocalDate.parse("2022-03-21")
+                ))
+                .build();
+
+        travelB = Travel.builder()
+                .id(2L)
+                .member(memberB)
+                .accompanyType(AccompanyType.CHILDREN)
+                .motivation(Motivation.EDUCATION)
+                .transportType(TransportType.PUBLIC)
+                .period(new TravelPeriod(
+                        LocalDate.parse("2022-08-15"),
+                        LocalDate.parse("2022-08-17")
+                ))
+                .accompanyType(AccompanyType.FRIENDS)
+                .build();
+
+        placeA = Place.builder()
+                .id(1L)
+                .name("그랜드 플라자 청주 호텔")
+                .location(new Location(36.6665, 127.4945))
+                .build();
+
+        placeB = Place.builder()
+                .id(2L)
+                .name("청주 시립 미술관")
+                .location(new Location(36.6347, 127.4784))
+                .build();
+
+        visitA = Visit.builder()
+                .id(1L).place(placeA).travel(travelA)
+                .build();
+
+        visitA2 = Visit.builder()
+                .id(2L).place(placeB).travel(travelA)
+                .build();
+
+        visitB = Visit.builder()
+                .id(3L).place(placeA).travel(travelB)
+                .build();
+
+        visitB2 = Visit.builder()
+                .id(4L).place(placeB).travel(travelB)
+                .build();
+
+        files = new ArrayList<>(LongStream.range(1, 11)
+                .mapToObj(id -> File.builder().id(id).build())
+                .toList());
+
+        Collections.shuffle(files);
+
+        files.forEach(file -> placeA.getFiles().add(file));
+    }
+
+
+    private VisitSearchResult createResult(Visit visit) {
+        return new VisitSearchResult(visit, visit.getTravel(), visit.getPlace(), 0.0);
+    }
+
+    private VisitSearchDTO performSearch() {
+        VisitSearch search = new VisitSearch();
+        List<VisitSearchResult> results = List.of(
+                createResult(visitA2),
+                createResult(visitB2),
+                createResult(visitB),
+                createResult(visitA)
+        );;
+
+        when(visitRepository.search(search)).thenReturn(results);
+
+        return visitSearchService.search(search);
+    }
+
+    @Test
+    public void 장소_중복() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+
+        assertThat(visitSearchDTO.getPlaces())
+                .as("장소는 ID 기준으로 중복되지 않아야 한다.")
+                .hasSize(2);
+    }
+
+    @Test
+    public void 장소_정렬() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+
+        assertThat(visitSearchDTO.getPlaces())
+                .extracting(PlaceDTO::getId)
+                .as("반환된 장소는 ID 오름차순으로 정렬되어야 한다.")
+                .containsExactly(1L, 2L);
+    }
+
+    @Test
+    public void 장소_미리보기_사진() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+
+        assertThat(visitSearchDTO.getPlaces().get(0).getImages())
+                .as("장소는 상위 5개의 미리보기 사진을 반환해야 한다.")
+                .hasSize(5)
+                .extracting(ImageDTO::getId)
+                .as("미리보기 사진은 ID 기준으로 오름차순으로 정렬되어야 한다.")
+                .containsExactly(1L, 2L, 3L, 4L, 5L);
+    }
+
+    @Test
+    public void 여행_참조_정렬() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+        List<Reference> travelRefs = List.of(
+                new Reference(1L, "travel"),
+                new Reference(2L, "travel"));
+
+        assertThat(visitSearchDTO.getPlaces())
+                .extracting(PlaceDTO::getTravels)
+                .as("장소는 연관된 여행의 참조 데이터를 반환해야 한다.")
+                .hasSize(2)
+                .containsExactly(travelRefs, travelRefs);
+    }
+
+    @Test
+    public void 장소_중복_검증() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+
+        assertThat(visitSearchDTO.getTravels())
+                .as("여행은 ID 기준으로 중복되지 않아야 한다.")
+                .hasSize(2);
+    }
+
+    @Test
+    public void 여행_정렬_검증() {
+        VisitSearchDTO visitSearchDTO = performSearch();
+
+        assertThat(visitSearchDTO.getTravels())
+                .extracting(TravelDTO::getId)
+                .as("반환된 여행은 ID 오름차순으로 정렬되어야 한다.")
+                .containsExactly(1L, 2L);
+    }
+
+
+}

--- a/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
+++ b/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
@@ -76,7 +76,7 @@ public class VisitSearchServiceTest {
                 .id(2L)
                 .member(memberB)
                 .accompanyType(AccompanyType.CHILDREN)
-                .motivation(Motivation.EDUCATION)
+                .motivation(Motivation.EDU)
                 .transportType(TransportType.PUBLIC)
                 .period(new TravelPeriod(
                         LocalDate.parse("2022-08-15"),
@@ -119,7 +119,7 @@ public class VisitSearchServiceTest {
 
         Collections.shuffle(files);
 
-        files.forEach(file -> placeA.getFiles().add(file));
+        files.forEach(file -> visitA.getFiles().add(file));
     }
 
 
@@ -134,7 +134,7 @@ public class VisitSearchServiceTest {
                 createResult(visitB2),
                 createResult(visitB),
                 createResult(visitA)
-        );;
+        );
 
         when(visitRepository.search(search)).thenReturn(results);
 


### PR DESCRIPTION
## 작업 개요
여행 로그 데이터셋 마이그레이션을 위해 객체의 속성 및 조회 로직을 변경하였음. 또한 각 장소의 중심시와의 거리(KM 단위)를 반환하였음

## 작업 사항
- [x] 조회 API의 중심지 거리(KM) 반환
    - [x] 레파지토리 반환 객체 정의 (VisitSearchResult)
- [x] 여행 로그 데이터셋 마이그레이션
    - [x] 실제 데이터와 불일치하는 속성 보완
    - [x] 이미지 데이터 첨부 대상 변경  
- [x] 이미지 상위 5개 반환 조건 추가, NPE 방지 로직 추가

## 고민한 점들
### DTO의 로직의 책임에 대해서
DTO에서 상위 N개 반환, 정렬, 중복 제거 등의 복잡한 조회 로직을 처리하고 있다. 처음에는 간단한 그래프 탐색 이었지만, 요구사항 추가로 인해 너무 복잡성이 증가하였다.

상위 N개 반환, 정렬, 중복 제거는 서비스 메서드의 요구 사항이고, 이는 서비스 레이어에 있는게 맞다고 판단하였다. 또한 테스트의 용이성도 있기에 이를 모두 서비스 레이어로 이관하였다. 앞으로 간단한 그래프 탐색, DTO Mapping을 제외한 조회 로직은 서비스 레이어에서 처리할 것이다.

### 파일 첨부 관리에 대해서
실제 데이터와 마이그레이션을 위해, 현재 File 테이블에서 travel, visit의 정보를 가지고 있다. 둘 다 N:1 관계이기 때문에 현재는 두 속성을 가지고 있어도 괜찮다고 생각하는데, 추후 요구사항이 확장된다면 이를 Image 혹은 Media 객체로 분리하는 방식을 사용해야 한다.

왜냐하면 현재 File 객체은 이미지 파일로 동작해 첨부 대상은 둘 밖에 없지만, 다른 타입의 파일(압축, 문서 등)은 첨부되서는 안되기 때문이다. 또한 데이터가 많을 시 컬럼을 추가하는 비용 또한 비싸기에, 별도의 Mapping 테이블로 분리할 수도 있겠다. 추후 생각하고 작업해보자.