### PR TITLE
performance: 주변 검색 성능 개선

### DIFF
--- a/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/dao/VisitRepository.java
@@ -63,7 +63,7 @@ public class VisitRepository {
 
     private BooleanTemplate dwithin(Location location, int radius) {
         return Expressions.booleanTemplate(
-                "st_dwithin({0}, {1}, {2}, false) is true",
+                "dwithin({0}, {1}, {2}, false)",
                 place.location.point,
                 location.getPoint(),
                 radius

--- a/src/main/java/com/yeohangttukttak/api/global/config/SpatialFunctionContributor.java
+++ b/src/main/java/com/yeohangttukttak/api/global/config/SpatialFunctionContributor.java
@@ -1,0 +1,16 @@
+package com.yeohangttukttak.api.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class SpatialFunctionContributor implements FunctionContributor {
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+                .register("dwithin", new StandardSQLFunction("st_dwithin", StandardBasicTypes.BOOLEAN));
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.yeohangttukttak.api.global.config.SpatialFunctionContributor


### PR DESCRIPTION
## 작업 개요
데이터 증가로 주변 검색의 소요 시간이 증가되어 공간 인덱스를 추가 및 활용하도록 구성하였음. 기존 HIbernate의 st_dwithin 호환성을 위해 Custom 방언을 등록하였음. 
## 작업 사항
- [x] Hibernate 방언에 st_dwithin 함수를 등록
- [x] Remote DB에 인덱스 생성
    - [x] File 테이블에 FK(place_id, file_id)에 대해 B-Tree 인덱스 생성
    - [x] Place 테이블에 Geography(Point)에 GiST 인덱스 생성   

## 고민한 점들
관련 트러블슈팅을 아래에 정리함
https://www.notion.so/2024-03-11-JPA-32c8c2c5a9054d6d8c924f879829eef3

## 스크린샷
![image](https://github.com/yeohaeng-ttukttak/yeohaeng-ttukttak-api/assets/89298198/eccb5cb9-99b4-4c94-8ad7-831b1902e345)
![image](https://github.com/yeohaeng-ttukttak/yeohaeng-ttukttak-api/assets/89298198/d7fa3983-7919-4d12-a694-af60227f38ea)

쿼리 소요시간을 324ms -> 51ms로 개선하였음. (38,000개 데이터, 20km 반경, 500개 결과)

![image](https://github.com/yeohaeng-ttukttak/yeohaeng-ttukttak-api/assets/89298198/a9a443e9-ac5d-4b91-8a59-4b72b7b02814)
원격 서버 500ms -> 145ms로 개선하였음 (동일 조건)