### PR TITLE
Feature: Google Place API 연동을 위한 ID 추가 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+
+
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.hibernate:hibernate-spatial:6.4.1.Final'
 	implementation 'com.querydsl:querydsl-spatial'

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
@@ -30,9 +30,6 @@ public class File extends BaseEntity {
 
     private String mimeType;
 
-//    @OneToOne(fetch = LAZY)
-//    private Travel travel;
-
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "visit_id")
     private Visit visit;

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -32,10 +32,13 @@ public class PlaceDTO {
 
     private List<Reference> travels;
 
+    private String googlePlaceId;
+
     public PlaceDTO(Place place) {
         this.id = place.getId();
         this.name = place.getName();
         this.type = place.getType();
+        this.googlePlaceId = place.getGooglePlaceId();
         this.location = new LocationDTO(place.getLocation());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,20 +5,13 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        highlight_sql: true
         default_batch_fetch_size: 1000
 
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:log4jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-
-logging:
-  level:
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql: trace
 
 management:
   endpoints:
@@ -28,3 +21,11 @@ management:
         include: health
   endpoint:
     health.enabled: true
+
+logging.level:
+    jdbc.sqlonly: off
+    jdbc.sqltiming: info
+    jdbc.resultsettable: off
+    jdbc.audit: off
+    jdbc.resultset: off
+    jdbc.connection: off

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,2 @@
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0


### PR DESCRIPTION
## 작업 개요
Google Place API 연동을 위해 실제 6만 건의 데이터를 Place API의 ID와 매칭 후 반환 DTO에 추가하였음

## 작업 사항
- [x] Google Place API 연동 작업

## 고민한 점들
### Google Place API 할당량 관련 트러블슈팅
![image](https://github.com/yeohaeng-ttukttak/yeohaeng-ttukttak-api/assets/89298198/a52513bf-b150-4b75-93e3-84118fb7a7d6)

Google Place API는 하루 7만 5천건, 분당 600개의 할당량을 가지고 있다. 문제는 별도 Throttle이 존재해서, 기재된 할당량보다 훨씬 적은 수라도 중간에 실패하는 경우가 많다. 자꾸 중간에 실패하니 현재까지 진행 상황이 다 소실되었다. 그래서 JS의 Write Stream을 이용해 해결하였다. API 호출 완료 시마다 별도 파일에 기록해 진행 상황을 지켜낼 수 있다.