### PR TITLE
Feature: 응답에 파일 URL 추가

### DIFF
--- a/src/main/java/com/yeohangttukttak/api/domain/file/dto/ImageDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/dto/ImageDTO.java
@@ -1,6 +1,7 @@
 package com.yeohangttukttak.api.domain.file.dto;
 
 import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.FileURL;
 import lombok.Data;
 
 @Data
@@ -10,9 +11,13 @@ public class ImageDTO {
 
     private String url;
 
+    private String mimeType;
+
     public ImageDTO (File file) {
         this.id = file.getId();
-        this.url = file.getUrl();
+        this.url = FileURL.create(file.getStorageType(),
+                          file.getPath(), file.getName());
+        this.mimeType = file.getMimeType();
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/File.java
@@ -2,15 +2,11 @@ package com.yeohangttukttak.api.domain.file.entity;
 
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
-import com.yeohangttukttak.api.global.interfaces.Attachable;
 import com.yeohangttukttak.api.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -26,7 +22,10 @@ public class File extends BaseEntity {
 
     private String name;
 
-    private String url;
+    private String path;
+
+    @Enumerated(EnumType.STRING)
+    private StorageType storageType;
 
     private String mimeType;
 
@@ -39,11 +38,10 @@ public class File extends BaseEntity {
     private Travel travel;
 
     @Builder
-    public File(Long id, String name, String url, String mimeType) {
+    public File(Long id, String name, String path, String mimeType) {
         this.id = id;
         this.name = name;
-        this.url = url;
+        this.path = path;
         this.mimeType = mimeType;
     }
-
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
@@ -1,0 +1,29 @@
+package com.yeohangttukttak.api.domain.file.entity;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FileURL {
+
+    private static String localPath;
+
+    @Value("${path.storage.local}")
+    public void setLocalPath(String localPath) {
+        FileURL.localPath = localPath;
+    }
+
+    public static String create(StorageType storageType,
+                                String path, String name) {
+        final StringBuilder sb = new StringBuilder();
+
+        if (storageType == StorageType.LOCAL) {
+            sb.append(localPath);
+        }
+
+        return sb.append(path)
+                .append(name)
+                .toString();
+    }
+
+}

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
@@ -2,28 +2,32 @@ package com.yeohangttukttak.api.domain.file.entity;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 public class FileURL {
 
-    private static String localPath;
+    private static String localHost;
 
-    @Value("${path.storage.local}")
-    public void setLocalPath(String localPath) {
-        FileURL.localPath = localPath;
+    @Value("${host.storage.local}")
+    public void setLocalPath(String localHost) {
+        FileURL.localHost = localHost;
     }
 
     public static String create(StorageType storageType,
                                 String path, String name) {
-        final StringBuilder sb = new StringBuilder();
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .newInstance()
+                .scheme("https");
 
         if (storageType == StorageType.LOCAL) {
-            sb.append(localPath);
+            builder.host(localHost);
         }
 
-        return sb.append(path)
-                .append(name)
-                .toString();
+        return builder.path(path)
+                .path(name)
+                .build().toString();
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/StorageType.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/StorageType.java
@@ -1,0 +1,5 @@
+package com.yeohangttukttak.api.domain.file.entity;
+
+public enum StorageType {
+    LOCAL;
+}

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
@@ -19,7 +19,6 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity @Getter
 @NoArgsConstructor(access = PROTECTED)
-@EqualsAndHashCode
 public class Travel extends BaseEntity implements Attachable {
 
     @Id @GeneratedValue

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,6 @@ logging.level:
     jdbc.resultset: off
     jdbc.connection: off
 
-path:
+host:
   storage:
     local: ${LOCAL_STORAGE_PATH}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,7 @@ logging.level:
     jdbc.audit: off
     jdbc.resultset: off
     jdbc.connection: off
+
+path:
+  storage:
+    local: ${LOCAL_STORAGE_PATH}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,3 +17,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+
+host:
+  storage:
+    local: test


### PR DESCRIPTION
## 작업 개요
파일 URL을 DB에 저장하는 방식에서, 애플리케이션 레벨에서 조립 후 전달하는 것으로 변경하였음

## 작업 사항
- [x] 파일 객체 속성 변경
- [x] URL 팩토리 클래스 생성 

## 고민한 점들(필수 X)
파일의 저장 위치(URL)을 DB에 직접 저장하는 것보다, 애플리케이션에서 조립 후 전달하는 방식을 사용했다. 다만 추후에 파일 마다 저장 위치가 달라질 수 있기에, 간단한 `Enum` 으로 관리하기로 했다.

이제 애플리케이션에서 저장 위치에 따라 알맞은 URL을 주입해야 한다. 나는 자바 코드에 직접 적지 않고, 환경 변수에서 가져와 주입할 것이다. 

- 실제 배포 환경에서 서버의 소스 코드를 바꾸는 것보다 환경 변수를 변경하는게 훨씬 쉽고 안전하다.
- 물론 URL은 공개되지만, 소스 코드에 기재하는 것이 껄끄럽다.

```yaml
path:
  storage:
    local: ${LOCAL_STORAGE_PATH} 
```

`application.yml` 에서 시스템 환경 변수를 주입하도록 구성했다. 이제 이 값을 애플리케이션에 주입해야 한다.

Spring은 `@Value`으로 쉽게 주입할 수 있다. 이쪽에 `${example.name}` 방식으로 전달하면 자동으로 해당 변수를 쉽게 가져올 수 있다.

### Static 변수에는 `@Value` 사용불가

---

```java

@Component
public class FileURL {

    private static String localPath;

    @Value("${path.storage.local}")
    public void setLocalPath(String localPath) {
        FileURL.localPath = localPath;
    }

    public static String create(StorageType storageType,
                                String path, String name) {
        final StringBuilder sb = new StringBuilder();

        if (storageType == StorageType.LOCAL) {
            sb.append(localPath);
        }

        return sb.append(path)
                .append(name)
                .toString();
    }

}

```

파일 URL을 생성하는 정적 메소드를 선언했지만, 값을 불러오지 못하는 문제가 발생했다. 왜 Static 필드에 값을 주입할 수 없을까?  이는 `@Value` 가 Spring의 Bean을 찾는 방식으로 주입하기 때문이다.

자바에서 static 필드는 인스턴스가 아닌 클래스 레벨에 속한다. 하지만 Spring의 Bean은 인스턴스 생명 주기를 관리하는 것이지, Static은 관리하지 않는다. 그래서 별도의 Setter를 사용해 명시적으로 선언해줘야 한다.

같은 원리로 `@Autowrired` 또한 작동하지 않는다.

> https://chunsubyeong.tistory.com/130
> 

### URiComponentBuilder

---

```java
@Component
public class FileURL {

    private static String localHost;

    @Value("${host.storage.local}")
    public void setLocalPath(String localHost) {
        FileURL.localHost = localHost;
    }

    public static String create(StorageType storageType,
                                String path, String name) {

        UriComponentsBuilder builder = UriComponentsBuilder
                .newInstance()
                .scheme("https");

        if (storageType == StorageType.LOCAL) {
            builder.host(localHost);
        }

        return builder.path(path)
                .path(name)
                .build().toString();
    }

}

```

URL을 생성하는 규칙을 복잡하다. 값의 저장과 실수 때문에 오류가 발생할 수 있다. 그래서 `UriComponentBuilder` 를 도입하였다.

> [[https://youngwonhan-family.tistory.com/entry/Spring-boot-URI-쉽게-만들기-with-UriComponentsBuilder](https://youngwonhan-family.tistory.com/entry/Spring-boot-URI-%EC%89%BD%EA%B2%8C-%EB%A7%8C%EB%93%A4%EA%B8%B0-with-UriComponentsBuilder)](https://youngwonhan-family.tistory.com/entry/Spring-boot-URI-%EC%89%BD%EA%B2%8C-%EB%A7%8C%EB%93%A4%EA%B8%B0-with-UriComponentsBuilder)
>

### EqualsAndHashCode 에러

---

Lombok의 `EqualsAndHashCode` 는 부모 클래스의 필드까지 고려할 것인지? 판단할 수 없기에 생긴 오류이다. 동등 비교를 위해 부모의 값 까지 고려할래?라는 뜻이다. 이 때 Lombok은`callSuper` false를 주는데, 클래스 상속 시 명시적으로 선언하자

> [[[TIL] Lombok 주의점 :: Study with me =) (tistory.com)](https://suintodev.tistory.com/27)](https://suintodev.tistory.com/27)
>