### PR TITLE
Performance: 관광지 사진 응답속도 개선

### DIFF
--- a/src/main/java/com/yeohangttukttak/api/domain/BaseEntity.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/BaseEntity.java
@@ -9,15 +9,16 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @MappedSuperclass
 @Getter @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
     @CreatedDate
-    private LocalDate createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDate modifiedAt;
+    private LocalDateTime modifiedAt;
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/dto/ImageDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/dto/ImageDTO.java
@@ -1,7 +1,7 @@
 package com.yeohangttukttak.api.domain.file.dto;
 
-import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.file.entity.FileURL;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 import lombok.Data;
 
 @Data
@@ -9,15 +9,21 @@ public class ImageDTO {
 
     private Long id;
 
-    private String url;
+    private String small;
 
-    private String mimeType;
+    private String medium;
 
-    public ImageDTO (File file) {
-        this.id = file.getId();
-        this.url = FileURL.create(file.getStorageType(),
-                          file.getPath(), file.getName());
-        this.mimeType = file.getMimeType();
+    private String large;
+
+    public ImageDTO (Image image) {
+        this.id = image.getId();
+
+        this.small = FileURL.create(image.getStorageType(),
+                "/_144", image.getPath(), image.getName());
+        this.medium = FileURL.create(image.getStorageType(),
+                "/_360", image.getPath(), image.getName());
+        this.large = FileURL.create(image.getStorageType(),
+                "/_720", image.getPath(), image.getName());
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/FileURL.java
@@ -2,7 +2,8 @@ package com.yeohangttukttak.api.domain.file.entity;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Arrays;
 
 @Component
 public class FileURL {
@@ -14,20 +15,16 @@ public class FileURL {
         FileURL.localHost = localHost;
     }
 
-    public static String create(StorageType storageType,
-                                String path, String name) {
+    public static String create(StorageType storageType, String... tokens) {
 
-        UriComponentsBuilder builder = UriComponentsBuilder
-                .newInstance()
-                .scheme("https");
+        StringBuilder sb = new StringBuilder();
 
         if (storageType == StorageType.LOCAL) {
-            builder.host(localHost);
+            sb.append(localHost);
         }
 
-        return builder.path(path)
-                .path(name)
-                .build().toString();
+        Arrays.stream(tokens).forEach(sb::append);
+        return sb.toString();
     }
 
 }

--- a/src/main/java/com/yeohangttukttak/api/domain/file/entity/Image.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/file/entity/Image.java
@@ -1,6 +1,5 @@
 package com.yeohangttukttak.api.domain.file.entity;
 
-import com.yeohangttukttak.api.domain.travel.entity.Travel;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.domain.BaseEntity;
 import jakarta.persistence.*;
@@ -8,16 +7,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class File extends BaseEntity {
+public class Image extends BaseEntity {
 
     @Id @GeneratedValue
-    @Column(name = "file_id")
+    @Column(name = "image_id")
     private Long id;
 
     private String name;
@@ -33,12 +35,8 @@ public class File extends BaseEntity {
     @JoinColumn(name = "visit_id")
     private Visit visit;
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "travel_id")
-    private Travel travel;
-
     @Builder
-    public File(Long id, String name, String path, String mimeType) {
+    public Image(Long id, String name, String path, String mimeType) {
         this.id = id;
         this.name = name;
         this.path = path;

--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -1,18 +1,11 @@
 package com.yeohangttukttak.api.domain.place.dto;
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
-import com.yeohangttukttak.api.domain.file.entity.File;
-import com.yeohangttukttak.api.domain.place.entity.Location;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.place.entity.PlaceType;
-import com.yeohangttukttak.api.domain.travel.entity.Travel;
-import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
-import com.yeohangttukttak.api.domain.visit.entity.Visit;
 import com.yeohangttukttak.api.global.common.Reference;
-import lombok.AllArgsConstructor;
 import lombok.Data;
 
 import java.util.*;
-import java.util.Map.Entry;
 
 import static java.util.Comparator.comparing;
 

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/dto/TravelDTO.java
@@ -1,14 +1,11 @@
 package com.yeohangttukttak.api.domain.travel.dto;
 
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
-import com.yeohangttukttak.api.domain.file.entity.File;
 import com.yeohangttukttak.api.domain.member.dto.MemberDTO;
-import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.AccompanyType;
 import com.yeohangttukttak.api.domain.travel.entity.Motivation;
 import com.yeohangttukttak.api.domain.travel.entity.TransportType;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
-import com.yeohangttukttak.api.domain.visit.dao.VisitSearchResult;
 import lombok.Data;
 
 import java.time.LocalDate;

--- a/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/travel/entity/Travel.java
@@ -1,13 +1,11 @@
 package com.yeohangttukttak.api.domain.travel.entity;
 
 import com.yeohangttukttak.api.domain.BaseEntity;
-import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 import com.yeohangttukttak.api.domain.member.entity.Member;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;
-import com.yeohangttukttak.api.global.interfaces.Attachable;
 import jakarta.persistence.*;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +17,7 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Entity @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Travel extends BaseEntity implements Attachable {
+public class Travel extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "travel_id")
@@ -46,8 +44,9 @@ public class Travel extends BaseEntity implements Attachable {
     @OneToMany(mappedBy = "travel")
     private List<Visit> visits = new ArrayList<>();
 
-    @OneToMany(mappedBy = "travel")
-    private List<File> files = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "thumbnail_id")
+    private Image thumbnail;
 
     @Builder
     public Travel(Long id, String name,

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/entity/Visit.java
@@ -1,10 +1,9 @@
 package com.yeohangttukttak.api.domain.visit.entity;
 
 import com.yeohangttukttak.api.domain.BaseEntity;
-import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
-import com.yeohangttukttak.api.global.interfaces.Attachable;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +19,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Visit extends BaseEntity implements Attachable {
+public class Visit extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "visit_id")
@@ -39,7 +38,7 @@ public class Visit extends BaseEntity implements Attachable {
     private Place place;
 
     @OneToMany(mappedBy = "visit")
-    private List<File> files = new ArrayList<>();
+    private List<Image> images = new ArrayList<>();
 
     @Builder
     public Visit(Long id, int dayOfTravel, int orderOfVisit, Place place, Travel travel) {

--- a/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/visit/service/VisitSearchService.java
@@ -1,7 +1,7 @@
 package com.yeohangttukttak.api.domain.visit.service;
 
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
-import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
 import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
 import com.yeohangttukttak.api.domain.travel.entity.Travel;
@@ -64,9 +64,9 @@ public class VisitSearchService {
     private List<ImageDTO> getPreviewImages(List<VisitSearchResult> results) {
         return results.stream()
                 .map(VisitSearchResult::getVisit)
-                .map(Visit::getFiles)
+                .map(Visit::getImages)
                 .flatMap(Collection::stream)
-                .sorted(comparing(File::getId))
+                .sorted(comparing(Image::getId))
                 .limit(5)
                 .map(ImageDTO::new)
                 .toList();
@@ -82,8 +82,7 @@ public class VisitSearchService {
     }
 
     private ImageDTO getThumbnail(Travel travel) {
-        File thumbnail = travel.getFiles().stream().findFirst().orElse(null);
-        return thumbnail == null ? null : new ImageDTO(thumbnail);
+        return travel.getThumbnail() == null ? null : new ImageDTO(travel.getThumbnail());
     }
 
 

--- a/src/main/java/com/yeohangttukttak/api/global/interfaces/Attachable.java
+++ b/src/main/java/com/yeohangttukttak/api/global/interfaces/Attachable.java
@@ -1,6 +1,6 @@
 package com.yeohangttukttak.api.global.interfaces;
 
-import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 
 import java.util.List;
 
@@ -8,6 +8,6 @@ public interface Attachable {
 
     public Long getId();
 
-    public List<File> getFiles();
+    public List<Image> getFiles();
 
 }

--- a/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
+++ b/src/test/java/com/yeohangttukttak/api/service/visit/VisitSearchServiceTest.java
@@ -1,7 +1,7 @@
 package com.yeohangttukttak.api.service.visit;
 
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
-import com.yeohangttukttak.api.domain.file.entity.File;
+import com.yeohangttukttak.api.domain.file.entity.Image;
 import com.yeohangttukttak.api.domain.member.entity.AgeGroup;
 import com.yeohangttukttak.api.domain.member.entity.Member;
 import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
@@ -45,7 +45,7 @@ public class VisitSearchServiceTest {
     Travel travelA, travelB;
     Place placeA, placeB;
     Visit visitA, visitB, visitA2, visitB2;
-    List<File> files;
+    List<Image> images;
 
     @BeforeEach
     public void init() {
@@ -113,13 +113,13 @@ public class VisitSearchServiceTest {
                 .id(4L).place(placeB).travel(travelB)
                 .build();
 
-        files = new ArrayList<>(LongStream.range(1, 11)
-                .mapToObj(id -> File.builder().id(id).build())
+        images = new ArrayList<>(LongStream.range(1, 11)
+                .mapToObj(id -> Image.builder().id(id).build())
                 .toList());
 
-        Collections.shuffle(files);
+        Collections.shuffle(images);
 
-        files.forEach(file -> visitA.getFiles().add(file));
+        images.forEach(file -> visitA.getImages().add(file));
     }
 
 


### PR DESCRIPTION
## 작업 개요
실제 기기로 테스트 해보니 4k 이미지를 로딩하는데 너무 시간이 오래 걸렸다. 그래 UI에 맞는 144, 360, 720p 이미지를 만들고, 각 URL을 반환하도록 했다.

## 작업 사항
- [x] 이미지 144, 360, 720p 생성 및 반환 (webP 압축 및 리사이즈) 
- [x] 여러 버전의 이미지 반환 API 작성

## 고민한 점들(필수 X)
### 어떻게 작업할 수 있을까
```bash
find images -name '*.jpg' | parallel convert '{}' -resize x360 -quality 100 '_360/{.}.webp'     
```
경로 그대로 앞에 `_144` 등을 붙여 변환해야 했다. 앞서 파일 앞 5글자를 sub 디렉토리로 만들었기 때문에, 어떻게 명령어를 짤지 고민이었다. 이를 위해 `find` 명령어와 `convert` 명령어를 파이프라인을 사용해 작업했다. 먼저 `rsync` 명령어로 원본과 똑같은 디렉토리를 만든 다음, find로 jpg 확장자를 찾고, 파이프라인된 경로를 기반으로 작업했다.

### 어떻게 여러 버전의 URL을 제공할 수 있을까?
<img width="1479" alt="image" src="https://github.com/yeohaeng-ttukttak/yeohaeng-ttukttak-api/assets/89298198/2d09da4c-9c22-4d59-b8c6-64ec1f6676b2">

첫 번째로 든 생각은 `JPA`의 셀프 참조를 이용해 원본 -> 144, 360, 720 이미지를 계층적으로 표현하고, 그래프 탐색으로 반환하도록 했다. 왜냐하면 추후 썸네일 등 계층적인 표현이 많을 것이라 생각했다.

그런데 이럴 경우 64만장의 이미지 데이터가 256만장으로 늘어나 성능 저하가 발생하고, 셀프 탐색을 할 때 약 2번의 쿼리가 더 발생해 성능 저하가 발생했다. 특히 클라이언트 입장에서 사용하기 힘들 것이라 생각했다.

생각을 좀더 간단하게 해봤다. 이미지들을 모두 같은 경로에 저장되어 있다고 생각한다면, 단순하게 앞에 `144`를 붙여 반환할 수 있었다. 그리고 만약 서버의 파일이 없다면 대체 이미지를 반환할 수 있다.

역시 너무 복잡하게 생각하니 오히려 독이 될 것 같다. 현재 상황과 목표에 맞는 간단한 답을 내도록 고민해보자.
