### PR TITLE
test: 여행 상세보기 API 테스트 코드 작성

### DIFF
--- a/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
+++ b/src/main/java/com/yeohangttukttak/api/domain/place/dto/PlaceDTO.java
@@ -4,13 +4,9 @@ import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
 import com.yeohangttukttak.api.domain.place.entity.Place;
 import com.yeohangttukttak.api.domain.place.entity.PlaceType;
 import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
-import com.yeohangttukttak.api.domain.visit.entity.Visit;
-import com.yeohangttukttak.api.global.common.Reference;
 import lombok.Data;
 
 import java.util.*;
-
-import static java.util.Comparator.comparing;
 
 
 @Data

--- a/src/test/java/com/yeohangttukttak/api/domain/place/dao/PlaceRepositoryTest.java
+++ b/src/test/java/com/yeohangttukttak/api/domain/place/dao/PlaceRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.yeohangttukttak.api.repository;
+package com.yeohangttukttak.api.domain.place.dao;
 
 import com.yeohangttukttak.api.domain.place.dao.PlaceRepository;
 import com.yeohangttukttak.api.domain.place.dto.PlaceFindNearbyQueryDTO;

--- a/src/test/java/com/yeohangttukttak/api/domain/place/service/PlaceFindNearbyServiceTest.java
+++ b/src/test/java/com/yeohangttukttak/api/domain/place/service/PlaceFindNearbyServiceTest.java
@@ -1,4 +1,4 @@
-package com.yeohangttukttak.api.service.place;
+package com.yeohangttukttak.api.domain.place.service;
 
 import com.yeohangttukttak.api.domain.file.dto.ImageDTO;
 import com.yeohangttukttak.api.domain.file.entity.Image;
@@ -9,7 +9,6 @@ import com.yeohangttukttak.api.domain.place.dto.PlaceFindNearbyQueryDTO;
 import com.yeohangttukttak.api.domain.place.dto.PlaceDTO;
 import com.yeohangttukttak.api.domain.place.entity.Location;
 import com.yeohangttukttak.api.domain.place.entity.Place;
-import com.yeohangttukttak.api.domain.place.service.PlaceFindNearbyService;
 import com.yeohangttukttak.api.domain.travel.dto.TravelDTO;
 import com.yeohangttukttak.api.domain.travel.entity.*;
 import com.yeohangttukttak.api.domain.visit.entity.Visit;

--- a/src/test/java/com/yeohangttukttak/api/domain/travel/service/TravelFindVisitsServiceTest.java
+++ b/src/test/java/com/yeohangttukttak/api/domain/travel/service/TravelFindVisitsServiceTest.java
@@ -1,0 +1,162 @@
+package com.yeohangttukttak.api.domain.travel.service;
+
+import com.yeohangttukttak.api.domain.file.entity.Image;
+import com.yeohangttukttak.api.domain.place.dto.LocationDTO;
+import com.yeohangttukttak.api.domain.place.entity.Location;
+import com.yeohangttukttak.api.domain.place.entity.Place;
+import com.yeohangttukttak.api.domain.place.entity.PlaceType;
+import com.yeohangttukttak.api.domain.travel.dto.BoundDTO;
+import com.yeohangttukttak.api.domain.travel.dto.TravelDaySummaryDTO;
+import com.yeohangttukttak.api.domain.travel.entity.*;
+import com.yeohangttukttak.api.domain.visit.dto.VisitDTO;
+import com.yeohangttukttak.api.domain.visit.entity.Visit;
+import com.yeohangttukttak.api.domain.visit.repository.VisitRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TravelFindVisitsServiceTest {
+
+    @InjectMocks
+    private TravelFindVisitsService travelFindVisitsService;
+
+    @Mock
+    private VisitRepository visitRepository;
+
+    Travel travel;
+    List<Visit> visits;
+    List<Image> images;
+
+    @BeforeEach
+    public void init() {
+
+        travel = Travel.builder().id(1L).build();
+
+        // Initialize Visits
+        visits = List.of(
+                createVisit(1L, 2, 2, "그랜드 플라자 청주 호텔", PlaceType.HOTEL, 33.0, 126.0),
+                createVisit(2L, 1, 2, "스누피가든", PlaceType.NATURE, 33.01, 126.01),
+                createVisit(3L, 3, 1, "청주 시립 미술관", PlaceType.CULTURE, 32.0, 125.0),
+                createVisit(4L, 2, 1, "섭지코지", PlaceType.NATURE, 36.0, 136.0)
+        );
+
+        // Initialize Images and shuffle for each visit
+        images = new ArrayList<>(LongStream.range(1, 11)
+                .mapToObj(id -> Image.builder().id(id).build())
+                .toList());
+
+        visits.forEach(visit -> {
+            Collections.shuffle(images);
+            images.forEach(image -> visit.getImages().add(image));
+        });
+
+        when(visitRepository.findByTravel(1L)).thenReturn(visits);
+
+    }
+
+    @Test
+    public void 방문_일자_그룹화() throws Exception {
+        // when
+        List<TravelDaySummaryDTO> result = travelFindVisitsService.find(1L);
+
+        // then
+        assertThat(result)
+                .extracting(TravelDaySummaryDTO::getDayOfTravel)
+                .as("여행의 방문 정보(방문 장소, 이미지, 순서)를 일자가 작은 순서(ASC)로 그룹화해 반환해야 한다.")
+                .containsExactly(1, 2);
+    }
+
+    @Test
+    public void 방문_순서_정렬() throws Exception {
+        // when
+        List<TravelDaySummaryDTO> result = travelFindVisitsService.find(1L);
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .as("방문 정보는 방문 순서(order_of_visit)가 작은 순서(ASC)로 반환해야 한다.")
+                .satisfiesExactly(
+                        daySummary -> assertThat(daySummary.getVisits())
+                                .extracting(VisitDTO::getOrderOfVisit)
+                                .containsExactly(2, 3),
+                        daySummary -> assertThat(daySummary.getVisits())
+                                .extracting(VisitDTO::getOrderOfVisit)
+                                .containsExactly(1, 2)
+                );
+    }
+
+
+    @Test
+    void 방문지_개별_클러스터링() throws Exception {
+        // when
+        List<TravelDaySummaryDTO> result = travelFindVisitsService.find(1L);
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .satisfiesExactly(
+                        daySummary -> assertThat(daySummary.getBound().getVisits())
+                                .as("일정 거리 이상 떨어진 경우 클러스터 영역에 포함하지 않는다.")
+                                .isEqualTo(List.of(
+                                        createBound(35.99, 135.99, 36.01, 136.01),
+                                        createBound(31.99, 124.99, 32.01, 125.01))),
+
+                        daySummary -> assertThat(daySummary.getBound().getVisits())
+                                .as("일정 거리 안에 있는 관광지를 포함한 영역을 반환한다.")
+                                .isEqualTo(List.of(
+                                        createBound(32.99, 125.99, 33.019999999999996, 126.02000000000001),
+                                        createBound(32.99, 125.99, 33.019999999999996, 126.02000000000001)))
+                );
+    }
+
+    @Test
+    void 방문지_전체_클러스터링() throws Exception {
+        // when
+        List<TravelDaySummaryDTO> result = travelFindVisitsService.find(1L);
+
+        // then
+        assertThat(result)
+                .hasSize(2)
+                .satisfiesExactly(
+                        daySummary -> assertThat(daySummary.getBound().getEntire())
+                                .as("첫 번째 여행 일자의 전체 영역 검증")
+                                .isEqualTo(createBound(32.0, 125.0, 36.0, 136.0)),
+                        daySummary -> assertThat(daySummary.getBound().getEntire())
+                                .as("두 번째 여행 일자의 전체 영역 검증")
+                                .isEqualTo(createBound(33.0, 126.0, 33.01, 126.01))
+                );
+    }
+
+
+    private Visit createVisit(Long id, int orderOfVisit, int dayOfTravel, String placeName, PlaceType placeType, double lat, double lon) {
+        Place place = Place.builder()
+                .name(placeName)
+                .type(placeType)
+                .location(new Location(lat, lon))
+                .build();
+
+        return Visit.builder()
+                .id(id)
+                .place(place)
+                .orderOfVisit(orderOfVisit)
+                .dayOfTravel(dayOfTravel)
+                .travel(travel)
+                .build();
+    }
+
+    private BoundDTO createBound(double lat1, double lon1, double lat2, double lon2) {
+        return new BoundDTO(new LocationDTO(lat1, lon1), new LocationDTO(lat2, lon2));
+    }
+}


### PR DESCRIPTION
## 작업 개요
- [x] 여행 상세보기 API의 정렬, 그룹화, 클러스터링 성공 테스트 추가
- [x] 기존 테스트 코드 경로를 domain 형으로 변경

## 작업 사항
테스트 코드를 작성하기 전에 API 명세를 다시 확인해보자.

1. 여행의 방문 정보(방문 장소, 이미지, 순서)를 일자가 작은 순서(ASC)로 그룹화해 반환한다.
2. 방문 정보는 방문 순서(order_of_visit)가 작은 순서(ASC)로 반환해야 한다.
3. 각 방문지에서 일정 거리에 떨어진 방문지를 포함하는 영역(남서, 북동 좌표)을 반환한다.
4. 모든 방문지를 포함하는  영역(남서, 북동 좌표)을 반환한다.

 비즈니스 로직에 예외를 발생하는 경우가 없으므로, 각 명세에 대해 성공하는 경우를 테스트하는 케이스만 작성했다. 

## 고민한 사항들
### 여러 테스트 케이스를 한번에 검사하기


```java
@Test
public void 방문_순서_정렬() throws Exception {
    // when
    List<TravelDaySummaryDTO> result = travelFindVisitsService.find(1L);

    // then
    assertThat(result)
            .hasSize(2)
            .as("방문 정보는 방문 순서(order_of_visit)가 작은 순서(ASC)로 반환해야 한다.")
            .satisfiesExactly(
                    daySummary -> assertThat(daySummary.getVisits())
                            .extracting(VisitDTO::getOrderOfVisit)
                            .containsExactly(2, 3),
                    daySummary -> assertThat(daySummary.getVisits())
                            .extracting(VisitDTO::getOrderOfVisit)
                            .containsExactly(1, 2)
            );
}

```

`sstaisfiesExatly` 라는 메서드를 알게 되었다. 이전까지 배열의 여러 요소를 점검하지만, 테스트 조건이 달라 일일이 인덱스를 탐색하면서 작성했는데, 이 메서드 덕분에 중복을 최소화할 수 있었다.

* 고차 함수를 원소 개수만큼 받는데, 순서(인덱스) 별로 다르게 테스트 케이스를 고차 함수로 작성할 수 있다.
